### PR TITLE
Master

### DIFF
--- a/lib/Pump.js
+++ b/lib/Pump.js
@@ -240,11 +240,7 @@
       return (this.currentRead = this._from.readAsync()).cancellable().then((function(_this) {
         return function(data) {
           _this.currentRead = null;
-          _this._processing = _this._process(data, _this);
-          if (!(_this._processing instanceof Promise)) {
-            _this._processing = void 0;
-            throw new Error(".process() did not return a Promise");
-          }
+          _this._processing = Promise.resolve(_this._process(data, _this));
           return _this._processing.cancellable();
         };
       })(this))["catch"](Promise.CancellationError, function() {})["catch"]((function(_this) {
@@ -308,7 +304,7 @@
 
     Pump.prototype.process = function(fn) {
       if (typeof fn !== 'function') {
-        throw new Error('.process() argument must be a Promise returning function ');
+        throw new Error('.process() argument must be a function ');
       }
       this._process = fn;
       return this;

--- a/lib/Pump.js
+++ b/lib/Pump.js
@@ -240,7 +240,11 @@
       return (this.currentRead = this._from.readAsync()).cancellable().then((function(_this) {
         return function(data) {
           _this.currentRead = null;
-          _this._processing = Promise.resolve(_this._process(data, _this));
+          _this._processing = _this._process(data, _this);
+          if (typeof _this._processing.then !== "function") {
+            _this._processing = void 0;
+            throw new Error(".process() did not return a Promise");
+          }
           return _this._processing.cancellable();
         };
       })(this))["catch"](Promise.CancellationError, function() {})["catch"]((function(_this) {

--- a/src/Pump.coffee
+++ b/src/Pump.coffee
@@ -145,7 +145,7 @@ module.exports = class Pump extends EventEmitter
       Promise.all(@buffer(buffer).writeAsync data for buffer in buffers)
 
   process: (fn) ->
-    throw new Error('.process() argument must be a Promise returning function ') if typeof fn != 'function'
+    throw new Error('.process() argument must be a function ') if typeof fn != 'function'
     @_process = fn
     @
 

--- a/src/Pump.coffee
+++ b/src/Pump.coffee
@@ -121,10 +121,7 @@ module.exports = class Pump extends EventEmitter
       .cancellable()
       .then (data) =>
         @currentRead = null
-        @_processing = @_process data, @
-        if not (@_processing instanceof Promise)
-          @_processing = undefined
-          throw new Error ".process() did not return a Promise"
+        @_processing = Promise.resolve(@_process data, @)        
         return @_processing.cancellable()
       .catch(Promise.CancellationError, ->)
       .catch (err) => @writeError err

--- a/src/Pump.coffee
+++ b/src/Pump.coffee
@@ -121,7 +121,10 @@ module.exports = class Pump extends EventEmitter
       .cancellable()
       .then (data) =>
         @currentRead = null
-        @_processing = Promise.resolve(@_process data, @)        
+        @_processing = @_process data, @
+        if typeof @_processing.then isnt "function"
+          @_processing = undefined
+          throw new Error ".process() did not return a Promise" 
         return @_processing.cancellable()
       .catch(Promise.CancellationError, ->)
       .catch (err) => @writeError err


### PR DESCRIPTION
The current code requires that the process function return a promise.  That's not ideal, but it's manageable.

However, the code that checked to see if the return object is a promise did so in such a way that it would only recognize a bluebird promise from the exact same bluebird module referenced by the datapumps package.  So if you used any other promise (native es6, another version of bluebird, etc, then it would fail).

This change uses bluebirds Promise.resolve, which will allow values or any object conforming to the promise spec.