### PR TITLE
CsvWriterMix 'end' handler issue

### DIFF
--- a/src/mixin/CsvWriterMixin.coffee
+++ b/src/mixin/CsvWriterMixin.coffee
@@ -64,6 +64,6 @@ CsvWriterMixin = (options) ->
 
     # Finishes writing the csv when the pump finishes.
     target.on 'end', ->
-      target._csv.writer.write(null)
+      target._csv.writer.end()
 
 module.exports = CsvWriterMixin


### PR DESCRIPTION
This relates to https://github.com/agmen-hu/node-datapumps/issues/46

It looks like the 'end' handler calls write(null) on the stream in the 'end' handler. That throws an uncaught error